### PR TITLE
Updated PrivacyPolicy.jsx

### DIFF
--- a/src/components/PrivacyPolicy/PrivacyPolicy.jsx
+++ b/src/components/PrivacyPolicy/PrivacyPolicy.jsx
@@ -1,10 +1,14 @@
 import './privacypolicy.css';
 import { privacyContext, policyContext } from './constant';
 import { Link } from 'react-router-dom'
+import { useEffect } from 'react';
 
 const PrivacyPolicy = () =>{
-
     
+    useEffect(() => {
+        //To  Scroll to the top of the page when the component is mounted
+        window.scrollTo(0, 0);
+    }, []);
 
     return(
         <section data-aos="fade down">


### PR DESCRIPTION
To  Scroll to the top of the page when the component is mounted (Issue #199)

## Related Issue
 This bug involves a situation where clicking on the privacy and policy link does not result in scrolling to the top of the privacy page or section. Instead, the user remains on the same line or position within the privacy content, causing navigation confusion and potentially affecting user experience.

## Description
To resolve the issue where clicking on the privacy policy link doesn't scroll to the top of the page or section, I have used a combination of React's useEffect and scrollTo method to ensure the page scrolls to the top whenever the component is rendered.

## Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)

https://github.com/user-attachments/assets/3ccd96ff-820c-4ca1-a1bf-2769ada43926


## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->



