### PR TITLE
Fixed Footer Alignment and Enhanced Contact Links

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -52,7 +52,7 @@ const Footer = () => {
                 <SocialLogo onClick={() => handleClick()}>EmoWell</SocialLogo>
               </FooterLinkItems>
               <FooterLinkItems>
-                <FooterLinkTitle style={{minWidth:"0px"}}><FooterLinkInitial><span style={{fontSize: "38px"}}>O</span></FooterLinkInitial>ur Contacts</FooterLinkTitle>
+                <FooterLinkTitle style={{minWidth:"0px", marginLeft:"-50px"}}><FooterLinkInitial><span style={{fontSize: "38px"}}>O</span></FooterLinkInitial>ur Contacts</FooterLinkTitle>
                 <FooterLinkItems>
                   <ListItem>
                     <ListItemIcon style={{minWidth:"0px"}}>

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -84,7 +84,9 @@ const Footer = () => {
                       trigger="hover"
                       colors="primary:#ffffff"></lord-icon>{" "}
                     </ListItemIcon>
-                    <ListItemText primary="+012 345 67890" />
+                    <a href="tel:+01234567890" style={{ textDecoration: 'none', color: 'inherit' }}>
+                      <ListItemText primary="+012 345 67890" />
+                    </a>
                   </ListItem>
                   <ListItem>
                     <ListItemIcon style={{minWidth:"0px"}}>
@@ -98,7 +100,9 @@ const Footer = () => {
                       trigger="hover"
                       colors="primary:#ffffff"></lord-icon>{" "}
                     </ListItemIcon>
-                    <ListItemText primary="abcdef@gmail.com" />
+                    <a href="mailto:abcdef@gmail.com" style={{ textDecoration: 'none', color: 'inherit' }}>
+                      <ListItemText primary="abcdef@gmail.com" />
+                    </a>
                   </ListItem>
                 </FooterLinkItems>
               </FooterLinkItems>

--- a/src/components/Footer/FooterElements.jsx
+++ b/src/components/Footer/FooterElements.jsx
@@ -186,3 +186,15 @@ export const WebsiteRights = styled.small`
   color: lime;
   font-size: 16px;
 `;
+
+export const ContactInfo = () => {
+  return (
+    <div>
+      <ListItem>
+        <a href="tel:+01234567890" style={{ textDecoration: 'none', color: 'inherit' }}>
+          <ListItemText primary="+012 345 67890" />
+        </a>
+      </ListItem>
+    </div>
+  );
+};

--- a/src/components/Footer/FooterElements.jsx
+++ b/src/components/Footer/FooterElements.jsx
@@ -186,15 +186,3 @@ export const WebsiteRights = styled.small`
   color: lime;
   font-size: 16px;
 `;
-
-export const ContactInfo = () => {
-  return (
-    <div>
-      <ListItem>
-        <a href="tel:+01234567890" style={{ textDecoration: 'none', color: 'inherit' }}>
-          <ListItemText primary="+012 345 67890" />
-        </a>
-      </ListItem>
-    </div>
-  );
-};


### PR DESCRIPTION
## Related Issue
Issue #285 solved

## Description
- Fixed alignment of the 'Our Contacts' Heading 
- Enhanced the contact links: clicking on the phone number and email id redirects to 'calling' and 'mailto'

## Type of PR

- [x] Bug fix
- [x] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
![Screenshot 2024-07-19 155453](https://github.com/user-attachments/assets/00d1b0c4-246d-4aa7-a055-549bdf353bb4)
![Screenshot 2024-07-19 155509](https://github.com/user-attachments/assets/89cf81ea-6d6d-4399-b48c-29a756ffa9fe)
[ContactLinks.webm](https://github.com/user-attachments/assets/3d6ae463-c120-41e3-9151-ba89ce22077c)


## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->
