### PR TITLE
add underline on footer links in our contacts and business hours section on hover

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -78,7 +78,7 @@ const Footer = () => {
                         colors="primary:#ffffff,secondary:#ffffff"
                       ></lord-icon>{" "}
                     </ListItemIcon>
-                    <ListItemText primary="ABCDEF, Rohini, ND-India" />
+                    <ListItemText primary="ABCDEF, Rohini, ND-India" className="footer-link" />
                   </ListItem>
                   <ListItem>
                     <ListItemIcon style={{ minWidth: "0px" }}>
@@ -94,7 +94,7 @@ const Footer = () => {
                       ></lord-icon>{" "}
                     </ListItemIcon>
                     <a href="tel:+01234567890" style={{ textDecoration: 'none', color: 'inherit' }}>
-                      <ListItemText primary="+012 345 67890" />
+                      <ListItemText primary="+012 345 67890" className="footer-link"/>
                     </a>
                   </ListItem>
                   <ListItem>
@@ -111,7 +111,7 @@ const Footer = () => {
                       ></lord-icon>{" "}
                     </ListItemIcon>
                     <a href="mailto:abcdef@gmail.com" style={{ textDecoration: 'none', color: 'inherit' }}>
-                      <ListItemText primary="abcdef@gmail.com" />
+                      <ListItemText primary="abcdef@gmail.com" className="footer-link"/>
                     </a>
                   </ListItem>
                 </FooterLinkItems>
@@ -191,13 +191,13 @@ const Footer = () => {
                 </FooterLinkTitle>
                 <FooterLinkItems style={{ marginRight: "50px" }}>
                   <ListItem>
-                    <ListItemText primary="Monday - Friday" />
+                    <ListItemText primary="Monday - Friday" className="footer-link" />
                   </ListItem>
                   <ListItem>
-                    <ListItemText primary="Saturday" />
+                    <ListItemText primary="Saturday" className="footer-link" />
                   </ListItem>
                   <ListItem>
-                    <ListItemText primary="Sunday" />
+                    <ListItemText primary="Sunday" className="footer-link"/>
                   </ListItem>
                 </FooterLinkItems>
               </FooterLinkItems>


### PR DESCRIPTION
## Related Issue
No underline under our contacts and business hours section in footer on hover

## Description
added underline on hover in our contacts and business hours section in footer

## Type of PR

- [x] Bug fix


## Checklist:
- [x ] I have performed a self-review of my code
- [ x] I have read and followed the Contribution Guidelines.
- [x ] I have tested the changes thoroughly before submitting this pull request.
- [ x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [ x] I have commented my code, particularly in hard-to-understand areas.



