### PR TITLE
Fix : Bug in mobile view navbar

### DIFF
--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -43,6 +43,7 @@ const Navbar = () => {
   };
 
   const handleLogoClick = () => {
+    setIsOpen(!isOpen);
     window.scrollTo(0, 0);
   };
 
@@ -57,6 +58,7 @@ const Navbar = () => {
 
   const handleNavClick = (path, sectionId) => {
     navigate(path);
+    setIsOpen(false);
     setTimeout(() => {
       scrollToSection(sectionId);
     }, 100);


### PR DESCRIPTION
## Related Issue
Fixes #353
## Description
We have to negate the setIsOpen whenever the onClick function on the navbar elements happens in mobile view.

## Type of PR

- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)

https://github.com/user-attachments/assets/fb760928-24c6-4a33-a79a-2f0914a003da

## Checklist:
- [X] I have performed a self-review of my code
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
[Include any additional information or context that might be helpful for reviewers.]
